### PR TITLE
header_presolve-parsers-sequel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "pandas",
         "plotly",
         "xlsxwriter",
-        "pre-commit",
     ],
     python_requires=">=3.6",
     include_package_data=True,

--- a/src/grblogtools/header_parser.py
+++ b/src/grblogtools/header_parser.py
@@ -14,14 +14,47 @@ class HeaderParser:
             "Gurobi Compute Server Worker version (?P<Version>\d{1,2}\.[^\s]+) build (.*) \((?P<Platform>[^\)]+)\)$"
         ),
         re.compile("Compute Server job ID: (?P<JobID>.*)$"),
+        re.compile("Set parameter (?P<ParamName>[^\s]+) to value (?P<ParamValue>.*)$"),
+        re.compile("Gurobi Optimizer version (?P<Version>\d{1,2}\.[^\s]+)"),
+    ]
+
+    # Possible intermediate patterns to be parsed
+    header_intermediate_patterns = [
+        re.compile("Set parameter (?P<ParamName>[^\s]+) to value (?P<ParamValue>.*)$"),
+        re.compile(
+            "Gurobi Compute Server Worker version (?P<Version>\d{1,2}\.[^\s]+) build (.*) \((?P<Platform>[^\)]+)\)$"
+        ),
+        re.compile("Compute Server job ID: (?P<JobID>.*)$"),
+        re.compile("Gurobi Optimizer version (?P<Version>\d{1,2}\.[^\s]+)"),
+        re.compile("Read (MPS|LP) format model from file (?P<ModelFilePath>.*)$"),
+        re.compile("Reading time = (?P<ReadingTime>[\d\.]+) seconds"),
+        re.compile(
+            "Thread count was (?P<Threads>\d+) \(of (?P<Cores>\d+) available processors\)"
+        ),
+        re.compile(
+            "Thread count: (?P<PhysicalCores>\d+) physical cores, (?P<LogicalProcessors>\d+) logical processors, using up to (?P<Threads>\d+) threads"
+        ),
     ]
 
     def __init__(self):
-        """Initialize the Header parser.
+        """Initialize the Header parser."""
+        self._summary = {}
 
-        The HeaderParser only includes one line.
-        """
-        self._log = {}
+    def _update_summary(self, match):
+        dict_ = match.groupdict()
+        if "ParamName" in dict_:
+            # Add the keyword "Param" at the beginning of the ParamName to make
+            # it clear it is a parameter
+            self._summary.update(
+                {"Param" + dict_["ParamName"]: convert_data_types(dict_["ParamValue"])}
+            )
+        else:
+            self._summary.update(
+                {
+                    sub_match: convert_data_types(value)
+                    for sub_match, value in dict_.items()
+                }
+            )
 
     def start_parsing(self, line: str) -> bool:
         """Return True if the parser should start parsing the future log lines.
@@ -36,13 +69,8 @@ class HeaderParser:
         for possible_start in HeaderParser.header_start_patterns:
             match = possible_start.match(line)
             if match:
-                # The start line encodes information that should to be stored
-                self._log.update(
-                    {
-                        sub_match: convert_data_types(value)
-                        for sub_match, value in match.groupdict().items()
-                    }
-                )
+                # The start line encodes information that should be stored
+                self._update_summary(match)
                 return True
         return False
 
@@ -55,11 +83,19 @@ class HeaderParser:
         Returns:
             bool: Return True.
         """
+        if not line.strip():
+            return True
+
+        for pattern in HeaderParser.header_intermediate_patterns:
+            match = pattern.match(line)
+            if match:
+                self._update_summary(match)
+                break
         return True
 
-    def get_log(self) -> dict:
-        """Return the current parsed log.
+    def get_summary(self) -> dict:
+        """Return the current parsed summary.
 
         It returns an empty dictionary if the parser is not initialized yet.
         """
-        return self._log
+        return self._summary

--- a/src/grblogtools/single_log_parser.py
+++ b/src/grblogtools/single_log_parser.py
@@ -20,8 +20,8 @@ class SingleLogParser:
 
     def get_summary(self):
         summary = {}
-        summary.update(self.header_parser.get_log())
-        summary.update(self.presolve_parser.get_log())
+        summary.update(self.header_parser.get_summary())
+        summary.update(self.presolve_parser.get_summary())
         summary.update(self.norel_parser.summary)
         summary.update(self.nodelog_parser.summary)
         return summary

--- a/tests/test_single_log_parser.py
+++ b/tests/test_single_log_parser.py
@@ -40,8 +40,8 @@ def test_single_log_parser():
     parser = SingleLogParser()
     parse_block(parser, full_log_data)
     # Test just that something is populated for all parsers.
-    assert parser.header_parser.get_log()
-    assert parser.presolve_parser.get_log()
+    assert parser.header_parser.get_summary()
+    assert parser.presolve_parser.get_summary()
     assert parser.norel_parser.summary
     assert parser.norel_parser.timeline
     assert parser.norel_parser.ignored_lines == 1


### PR DESCRIPTION
This PR addresses the comments in #12. 

I left `get_summary()` as a method and did not make it a property. To me, leaving `get_summary()`, `get_log()` or `get_timelines()` as methods make more sense but we can discuss it later.  

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201705063151516