### PR TITLE
Handle merged log files

### DIFF
--- a/src/grblogtools/api.py
+++ b/src/grblogtools/api.py
@@ -43,13 +43,13 @@ class ParseResult:
         """Construct and return a summary dataframe for all parsed logs."""
         summary = pd.DataFrame(
             [
-                dict(parser.get_summary(), LogFilePath=logfile)
-                for logfile, parser in self.parsers
+                dict(parser.get_summary(), LogFilePath=logfile, LogNumber=lognumber)
+                for logfile, lognumber, parser in self.parsers
             ]
         )
         # Post-processing to match old API
         parameters = pd.DataFrame(
-            [parser.header_parser.get_parameters() for _, parser in self.parsers]
+            [parser.header_parser.get_parameters() for _, _, parser in self.parsers]
         )
         if "Seed" in parameters.columns:
             seed = parameters[["Seed"]].fillna(0).astype(int)
@@ -78,7 +78,7 @@ class ParseResult:
         """Parse a single file. The log file may contain multiple run logs."""
         parser = SingleLogParser()
         subsequent = SingleLogParser()
-        log_count = 0
+        lognumber = 1
         with open(logfile) as infile:
             lines = iter(infile)
             for line in lines:
@@ -87,16 +87,12 @@ class ParseResult:
                     if subsequent.parse(line):
                         # The current parser did not match but an empty parser
                         # matched a header line.
-                        log_count += 1
-                        self.parsers.append((f"{logfile}({log_count})", parser))
+                        self.parsers.append((logfile, lognumber, parser))
+                        lognumber += 1
                         parser = subsequent
                         subsequent = SingleLogParser()
 
-        if log_count:
-            log_count += 1
-            self.parsers.append((f"{logfile}({log_count})", parser))
-        else:
-            self.parsers.append((logfile, parser))
+        self.parsers.append((logfile, lognumber, parser))
 
 
 def parse(arg: str) -> ParseResult:

--- a/tests/parsers/test_single_log.py
+++ b/tests/parsers/test_single_log.py
@@ -1,7 +1,16 @@
 import pytest
 
 from grblogtools.parsers.single_log import SingleLogParser
-from grblogtools.parsers.util import parse_lines
+
+
+def parse_lines(parser, loglines):
+    """Parse the given lines using the given parser object.
+
+    This function is mainly used in the tests. Updated for simpler API.
+    """
+    lines = iter(loglines)
+    for line in lines:
+        parser.parse(line)
 
 
 def test_mip_norel_log():
@@ -20,6 +29,7 @@ def test_mip_norel_log():
     # Combined summary data.
     summary = parser.get_summary()
     assert summary["Version"] == "9.1.2"
+    assert summary["Platform"] == "mac64, gurobi_cl"
     assert summary["NumVars"] == 322
     assert summary["PresolvedNumIntVars"] == 297
     assert summary["NoRelBestSol"] == 1.200013e09

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,12 +32,12 @@ def merged_log():
 
 def test_merged_log(merged_log):
     summary = glt.parse(merged_log).summary()
-    result = summary[["Seed", "Runtime", "LogFilePath"]]
+    result = summary[["Seed", "Runtime", "LogFilePath", "LogNumber"]]
     expected = pd.DataFrame(
         [
-            {"Seed": 0, "Runtime": 35.66, "LogFilePath": f"{merged_log}(1)"},
-            {"Seed": 1, "Runtime": 42.79, "LogFilePath": f"{merged_log}(2)"},
-            {"Seed": 2, "Runtime": 11.37, "LogFilePath": f"{merged_log}(3)"},
+            {"Seed": 0, "Runtime": 35.66, "LogFilePath": merged_log, "LogNumber": 1},
+            {"Seed": 1, "Runtime": 42.79, "LogFilePath": merged_log, "LogNumber": 2},
+            {"Seed": 2, "Runtime": 11.37, "LogFilePath": merged_log, "LogNumber": 3},
         ]
     )
     assert_frame_equal(result, expected)


### PR DESCRIPTION
Updated parser API to handle multiple logs within one file. This is done automatically, a `merged_logs` argument is not required. If there are multiple logs in a file, suffixes `(1)`, `(2)`, etc are aded to `LogFilePath`.

Also simplified SingleLogParser API to use a single parse() method, which cleans up the outer loop.