### PR TITLE
termination-timelines

### DIFF
--- a/src/grblogtools/api.py
+++ b/src/grblogtools/api.py
@@ -39,15 +39,33 @@ class ParseResult:
     def __init__(self):
         self.parsers = []
 
-    def progress(self):
+    def progress(self) -> dict:
+        """Return the optimization search progress.
+
+        Returns:
+            dict: A key-value pair in the form {"norel": pd.DataFrame,
+            "rootlp": pd.DataFrame, "nodelog": pd.DataFrame}.
+        """
         nodelog = pd.DataFrame(
-            [row for _, parser in self.parsers for row in parser.get_nodelog_progress()]
+            [
+                dict(row, LogFilePath=logfile, LogNumber=lognumber)
+                for logfile, lognumber, parser in self.parsers
+                for row in parser.get_nodelog_progress()
+            ]
         )
         norel = pd.DataFrame(
-            [row for _, parser in self.parsers for row in parser.get_norel_progress()]
+            [
+                dict(row, LogFilePath=logfile, LogNumber=lognumber)
+                for logfile, lognumber, parser in self.parsers
+                for row in parser.get_norel_progress()
+            ]
         )
         rootlp = pd.DataFrame(
-            [row for _, parser in self.parsers for row in parser.get_rootlp_progress()]
+            [
+                dict(row, LogFilePath=logfile, LogNumber=lognumber)
+                for logfile, lognumber, parser in self.parsers
+                for row in parser.get_rootlp_progress()
+            ]
         )
         return {
             "rootlp": rootlp,
@@ -119,7 +137,6 @@ def parse(arg: str) -> ParseResult:
 
     TODO extend this, a list of patterns, or a vararg of patterns, should also work.
     """
-
     result = ParseResult()
     for logfile in glob.glob(arg):
         result.parse(logfile)
@@ -131,9 +148,9 @@ def get_dataframe(logfiles, timelines=False):
     """Compatibility function for the legacy API.
 
     Args:
-        logfiles (str): Path pattern to log files.
-        timeliens (bool, optional): Return the timeline progress if set to True.
-            Default False.
+        logfiles (str): A glob pattern of the log files.
+        timeliens (bool, optional): Return the norel, the relaxation, and the
+            search tree progress if set to True. Defaults to False.
     """
     result = parse(*logfiles)
     if not timelines:

--- a/src/grblogtools/api.py
+++ b/src/grblogtools/api.py
@@ -39,6 +39,22 @@ class ParseResult:
     def __init__(self):
         self.parsers = []
 
+    def progress(self):
+        nodelog = pd.DataFrame(
+            [row for _, parser in self.parsers for row in parser.get_nodelog_progress()]
+        )
+        norel = pd.DataFrame(
+            [row for _, parser in self.parsers for row in parser.get_norel_progress()]
+        )
+        rootlp = pd.DataFrame(
+            [row for _, parser in self.parsers for row in parser.get_rootlp_progress()]
+        )
+        return {
+            "rootlp": rootlp,
+            "norel": norel,
+            "nodelog": nodelog,
+        }
+
     def summary(self):
         """Construct and return a summary dataframe for all parsed logs."""
         summary = pd.DataFrame(
@@ -107,13 +123,23 @@ def parse(arg: str) -> ParseResult:
 
     TODO extend this, a list of patterns, or a vararg of patterns, should also work.
     """
+
     result = ParseResult()
     for logfile in glob.glob(arg):
         result.parse(logfile)
+
     return result
 
 
-def get_dataframe(logfiles):
-    """Compatibility function for the legacy API."""
+def get_dataframe(logfiles, timelines=False):
+    """Compatibility function for the legacy API.
+
+    Args:
+        logfiles (str): Path pattern to log files.
+        timeliens (bool, optional): Return the timeline progress if set to True.
+            Default False.
+    """
     result = parse(*logfiles)
-    return result.summary()
+    if not timelines:
+        return result.summary()
+    return result.summary(), result.progress()

--- a/src/grblogtools/parsers/barrier.py
+++ b/src/grblogtools/parsers/barrier.py
@@ -29,6 +29,10 @@ class BarrierParser:
         ),
     ]
 
+    barrier_interruption_pattern = re.compile(
+        r"Barrier solve interrupted - model solved by another algorithm"
+    )
+
     def __init__(self):
         """Initialize the Barrier parser."""
         self._summary = {}
@@ -73,6 +77,11 @@ class BarrierParser:
             return True
 
         return False
+
+    def is_interrupted(self, line: str) -> bool:
+        """Return True if the given line matches the interruption pattern."""
+        if BarrierParser.barrier_interruption_pattern.match(line):
+            return True
 
     def get_summary(self) -> dict:
         """Return the current parsed summary."""

--- a/src/grblogtools/parsers/barrier.py
+++ b/src/grblogtools/parsers/barrier.py
@@ -9,6 +9,8 @@ class BarrierParser:
         r"Iter(\s+)Primal(\s+)Dual(\s+)Primal(\s+)Dual(\s+)Compl(\s+)Time"
     )
 
+    barrier_ordering_pattern = re.compile(r"Ordering time: (?P<OrderingTime>[\d\.]+)s")
+
     # The pattern indicating the barrier progress
     barrier_progress_pattern = re.compile(
         r"\s*(?P<Iteration>\d+)(?P<Indicator>\s|\*)\s+(?P<PObj>[^\s]+)\s+(?P<DObj>[^\s]+)\s+(?P<PRes>[^\s]+)\s+(?P<DRes>[^\s]+)\s+(?P<Compl>[^\s]+)\s+(?P<Time>\d+)s"
@@ -48,6 +50,10 @@ class BarrierParser:
             bool: Return True if the given line matches the parser start patterns.
         """
         if BarrierParser.barrier_start_pattern.match(line):
+            return True
+        barrier_ordering_match = BarrierParser.barrier_ordering_pattern.match(line)
+        if barrier_ordering_match:
+            self._summary.update(typeconvert_groupdict(barrier_ordering_match))
             return True
         return False
 

--- a/src/grblogtools/parsers/continuous.py
+++ b/src/grblogtools/parsers/continuous.py
@@ -21,7 +21,7 @@ class ContinuousParser:
         self._summary = {}
         self._progress = []
 
-        self._start_pattern = None
+        self._current_pattern = None
 
     def start_parsing(self, line: str) -> bool:
         """Return True if the parser should start parsing the future log lines.
@@ -33,16 +33,16 @@ class ContinuousParser:
             bool: Return True if the given line matches the parser start patterns.
         """
         if self._barrier_parser.start_parsing(line):
-            self._start_pattern = "barrier"
+            self._current_pattern = "barrier"
             return True
 
         if self._simplex_parser.start_parsing(line):
-            self._start_pattern = "simplex"
+            self._current_pattern = "simplex"
             return True
 
         mip_relaxation_match = ContinuousParser.mip_relaxation_pattern.match(line)
         if mip_relaxation_match:
-            self._start_pattern = "relaxation"
+            self._current_pattern = "relaxation"
             self._summary.update(typeconvert_groupdict(mip_relaxation_match))
             return True
 
@@ -62,27 +62,30 @@ class ContinuousParser:
             self._summary.update(typeconvert_groupdict(mip_relaxation_match))
             return False
 
-        if self._start_pattern == "barrier":
-            return self._barrier_parser.continue_parsing(line)
-        if self._start_pattern == "simplex":
+        if self._current_pattern == "barrier":
+            matched = self._barrier_parser.continue_parsing(line)
+            # If the barrier gets interrupted during the concurrent, switch to
+            # the simplex
+            if not matched and self._barrier_parser.is_interrupted(line):
+                self._current_pattern = "simplex"
+            return matched
+        if self._current_pattern == "simplex":
             return self._simplex_parser.continue_parsing(line)
-        if self._start_pattern == "relaxation":
+        if self._current_pattern == "relaxation":
             return False
 
         return True
 
     def get_summary(self) -> dict:
         """Return the current parsed summary."""
-        if self._start_pattern == "barrier":
-            self._summary.update(self._barrier_parser.get_summary())
-        elif self._start_pattern == "simplex":
-            self._summary.update(self._simplex_parser.get_summary())
+        self._summary.update(self._barrier_parser.get_summary())
+        self._summary.update(self._simplex_parser.get_summary())
         return self._summary
 
     def get_progress(self) -> list:
         """Return the detailed progress in the continuous method."""
-        if self._start_pattern == "barrier":
-            return self._barrier_parser.get_progress()
-        if self._start_pattern == "simplex":
-            return self._simplex_parser.get_progress()
-        return self._progress
+        return (
+            self._barrier_parser.get_progress()
+            + self._simplex_parser.get_progress()
+            + self._progress
+        )

--- a/src/grblogtools/parsers/nodelog.py
+++ b/src/grblogtools/parsers/nodelog.py
@@ -104,3 +104,6 @@ class NodeLogParser:
         if line.strip() and not self._complete:
             self.ignored_lines += 1
         return False
+
+    def get_progress(self):
+        return self.timeline

--- a/src/grblogtools/parsers/nodelog.py
+++ b/src/grblogtools/parsers/nodelog.py
@@ -9,7 +9,7 @@ float_pattern = r"[-+]?((\d*\.\d+)|(\d+\.?))([Ee][+-]?\d+)?"
 class NodeLogParser:
     """
     Methods:
-        - log_start(line) -> parse a string, returing true if this string
+        - log_start(line) -> parse a string, returning true if this string
           indicates the start of the norel section
         - parse(line) -> parse a string, return true if this parser should
           continue receiving future log lines
@@ -17,7 +17,7 @@ class NodeLogParser:
     Attributes:
         - timeline -> list of dicts for log timeline entries (incumbent, bound,
           time, depth, etc)
-        - ignored_lines -> count of lines after the log start which were recieved
+        - ignored_lines -> count of lines after the log start which were received
           but not parsed
     """
 
@@ -105,5 +105,6 @@ class NodeLogParser:
             self.ignored_lines += 1
         return False
 
-    def get_progress(self):
+    def get_progress(self) -> list:
+        """Return the progress of the search tree."""
         return self.timeline

--- a/src/grblogtools/parsers/norel.py
+++ b/src/grblogtools/parsers/norel.py
@@ -63,5 +63,5 @@ class NoRelParser:
         return False
 
     def get_progress(self) -> list:
-        """Return the progress of the No-Relaxation heuristic."""
+        """Return the progress of the norel heuristic."""
         return self.timeline

--- a/src/grblogtools/parsers/norel.py
+++ b/src/grblogtools/parsers/norel.py
@@ -61,3 +61,6 @@ class NoRelParser:
                 self.timeline.append(entry)
                 return True
         return False
+
+    def get_progress(self):
+        return self.timeline

--- a/src/grblogtools/parsers/norel.py
+++ b/src/grblogtools/parsers/norel.py
@@ -62,5 +62,6 @@ class NoRelParser:
                 return True
         return False
 
-    def get_progress(self):
+    def get_progress(self) -> list:
+        """Return the progress of the No-Relaxation heuristic."""
         return self.timeline

--- a/src/grblogtools/parsers/single_log.py
+++ b/src/grblogtools/parsers/single_log.py
@@ -43,6 +43,18 @@ class SingleLogParser:
         summary.update(self.termination_parser.get_summary())
         return summary
 
+    def get_nodelog_progress(self):
+        """Return the progress of exploring nodes in the tree search."""
+        return self.nodelog_parser.get_progress()
+
+    def get_norel_progress(self):
+        """Return the progress of the No-Relaxation heuristic."""
+        return self.norel_parser.get_progress()
+
+    def get_rootlp_progress(self):
+        """Return the progress continuous relaxation algorithm."""
+        return self.continuous_parser.get_progress()
+
     def parse(self, line: str) -> bool:
         """Parse the given log line.
 

--- a/src/grblogtools/parsers/single_log.py
+++ b/src/grblogtools/parsers/single_log.py
@@ -29,7 +29,6 @@ class SingleLogParser:
             self.norel_parser,
             self.continuous_parser,
             self.nodelog_parser,
-            self.termination_parser,
         ]
 
     def get_summary(self):
@@ -73,6 +72,9 @@ class SingleLogParser:
                 self.current_parser = parser
                 self.future_parsers = self.future_parsers[i + 1 :]
                 return True
+
+        # Check if the line matches any pattern of the termination parser.
+        self.termination_parser.parse(line)
 
         # Nothing matched.
         return False

--- a/src/grblogtools/parsers/single_log.py
+++ b/src/grblogtools/parsers/single_log.py
@@ -44,11 +44,11 @@ class SingleLogParser:
         return summary
 
     def get_nodelog_progress(self):
-        """Return the progress of the tree search."""
+        """Return the progress of the search tree."""
         return self.nodelog_parser.get_progress()
 
     def get_norel_progress(self):
-        """Return the progress of the No-Relaxation heuristic."""
+        """Return the progress of the norel heuristic."""
         return self.norel_parser.get_progress()
 
     def get_rootlp_progress(self):

--- a/src/grblogtools/parsers/single_log.py
+++ b/src/grblogtools/parsers/single_log.py
@@ -44,7 +44,7 @@ class SingleLogParser:
         return summary
 
     def get_nodelog_progress(self):
-        """Return the progress of exploring nodes in the tree search."""
+        """Return the progress of the tree search."""
         return self.nodelog_parser.get_progress()
 
     def get_norel_progress(self):
@@ -52,7 +52,7 @@ class SingleLogParser:
         return self.norel_parser.get_progress()
 
     def get_rootlp_progress(self):
-        """Return the progress continuous relaxation algorithm."""
+        """Return the progress of the continuous algorithm."""
         return self.continuous_parser.get_progress()
 
     def parse(self, line: str) -> bool:
@@ -64,7 +64,6 @@ class SingleLogParser:
         Returns:
             bool: Return True if the given line is matched.
         """
-
         # Initially, only check the header parser until started.
         if not self.started:
             assert self.current_parser is self.header_parser

--- a/src/grblogtools/parsers/single_log.py
+++ b/src/grblogtools/parsers/single_log.py
@@ -43,18 +43,6 @@ class SingleLogParser:
         summary.update(self.termination_parser.get_summary())
         return summary
 
-    def get_nodelog_progress(self):
-        """Return the progress of the search tree."""
-        return self.nodelog_parser.get_progress()
-
-    def get_norel_progress(self):
-        """Return the progress of the norel heuristic."""
-        return self.norel_parser.get_progress()
-
-    def get_rootlp_progress(self):
-        """Return the progress of the continuous algorithm."""
-        return self.continuous_parser.get_progress()
-
     def parse(self, line: str) -> bool:
         """Parse the given log line.
 
@@ -85,7 +73,8 @@ class SingleLogParser:
                 return True
 
         # Check if the line matches any pattern of the termination parser.
-        self.termination_parser.parse(line)
+        if self.termination_parser.parse(line):
+            return True
 
         # Nothing matched.
         return False

--- a/src/grblogtools/parsers/termination.py
+++ b/src/grblogtools/parsers/termination.py
@@ -35,6 +35,9 @@ class TerminationParser:
             r"(?P<INTERRUPTED>(Interrupt request received|Solve interrupted))(?: \\(error code (?P<ErrorCode>[^\\)]+)\\))?"
         ),
         re.compile(r"Solution count (?P<SolCount>\d+)"),
+        re.compile(
+            r"Thread count was (?P<Threads>\d+) \(of (?P<Cores>\d+) available processors\)"
+        ),
     ]
 
     status = [

--- a/src/grblogtools/parsers/termination.py
+++ b/src/grblogtools/parsers/termination.py
@@ -4,46 +4,69 @@ from grblogtools.parsers.util import typeconvert_groupdict
 
 
 class TerminationParser:
-
+    # Termination patterns
     patterns = [
-        re.compile(r"Solution count (?P<SolCount>\d+)"),
         re.compile(
             r"Best objective (?P<ObjVal>[^,]+), best bound (?P<ObjBound>[^,]+), gap (?P<MIPGap>.*)$"
         ),
+        re.compile(r"ERROR (?P<ErrorCode>[^:]+): (?P<ErrorMessage>.*)$"),
+        re.compile(r"\[(?P<ErrorMessage>process terminated with exit code [^\\]]+)\]$"),
+        re.compile(r"(?P<TIME_LIMIT>Time limit reached)"),
+        re.compile(r"(?P<OPTIMAL>Optimal solution found)(?: \(tolerance .*\))"),
+        re.compile(r"(?P<OPTIMAL>Optimal objective\s+(?P<ObjVal>.*))$"),
+        re.compile(r"(?P<ITERATION_LIMIT>Iteration limit reached)"),
+        re.compile(r"(?P<INF_OR_UNBD>Infeasible or unbounded model)"),
+        re.compile(r"(?P<INF_OR_UNBD>Model is infeasible or unbounded)"),
+        re.compile(r"(?P<UNBOUNDED>Unbounded model)"),
+        re.compile(r"(?P<UNBOUNDED>Model is unbounded)"),
+        re.compile(r"(?P<INFEASIBLE>Infeasible model)"),
+        re.compile(r"(?P<INFEASIBLE>Model is infeasible)"),
+        re.compile(r"(?P<SOLUTION_LIMIT>Solution limit reached)"),
+        re.compile(r"(?P<NODE_LIMIT>Node limit reached)"),
+        re.compile(r"(?P<NUMERIC>Numeric error)"),
+        re.compile(r"(?P<NUMERIC>Numerical trouble encountered)"),
         re.compile(
-            r"Thread count was (?P<Threads>\d+) \(of (?P<Cores>\d+) available processors\)"
+            r"(?P<SUBOPTIMAL>Sub-optimal termination)(?: - objective (?P<ObjVal>.*))$"
         ),
+        re.compile(r"(?P<CUTOFF>Model objective exceeds cutoff)"),
+        re.compile(r"(?P<CUTOFF>Objective cutoff exceeded)"),
+        re.compile(r"(?P<USER_OBJ_LIMIT>Optimization achieved user objective limit)"),
+        re.compile(
+            r"(?P<INTERRUPTED>(Interrupt request received|Solve interrupted))(?: \\(error code (?P<ErrorCode>[^\\)]+)\\))?"
+        ),
+        re.compile(r"Solution count (?P<SolCount>\d+)"),
     ]
 
-    re_termination_status = {
-        "OPTIMAL": re.compile(
-            r"(?P<OPTIMAL>Optimal solution found)(?: \(tolerance .*\))"
-        ),
-        "TIME_LIMIT": re.compile(r"(?P<TIME_LIMIT>Time limit reached)"),
-    }
+    status = [
+        "OPTIMAL",
+        "TIME_LIMIT",
+        "ITERATION_LIMIT",
+        "INF_OR_UNBD",
+        "UNBOUNDED",
+        "INFEASIBLE",
+        "SOLUTION_LIMIT",
+        "NUMERIC",
+        "SUBOPTIMAL",
+        "CUTOFF",
+        "USER_OBJ_LIMIT",
+        "INTERRUPTED",
+    ]
 
     def __init__(self):
         self._summary = {}
 
-    def _parse(self, line: str) -> bool:
-        """No specific section start, so start and continue are the same."""
-        for pattern in self.patterns:
+    def parse(self, line: str) -> bool:
+        """Return True if the line is matched by one of the patterns."""
+        for pattern in TerminationParser.patterns:
             match = pattern.match(line)
             if match:
-                self._summary.update(typeconvert_groupdict(match))
-                return True
-        for status, pattern in self.re_termination_status.items():
-            match = pattern.match(line)
-            if match:
-                self._summary["Status"] = status
+                for key, value in typeconvert_groupdict(match).items():
+                    if key in TerminationParser.status:
+                        self._summary.update({"Status": key})
+                    else:
+                        self._summary.update({key: value})
                 return True
         return False
-
-    def start_parsing(self, line: str) -> bool:
-        return self._parse(line)
-
-    def continue_parsing(self, line: str) -> bool:
-        return self._parse(line)
 
     def get_summary(self) -> dict:
         return self._summary

--- a/tests/parsers/test_continuous.py
+++ b/tests/parsers/test_continuous.py
@@ -85,6 +85,32 @@ expected_progress_barrier = [
     },
 ]
 
+example_log_concurrent = """
+Iter       Primal          Dual         Primal    Dual     Compl     Time
+   0   4.56435085e+07  1.53061018e+04  1.69e+05 8.58e+00  1.59e+03     2s
+
+Barrier performed 7 iterations in 4.02 seconds (4.19 work units)
+Barrier solve interrupted - model solved by another algorithm
+
+
+Solved with dual simplex
+Solved in 69986 iterations and 4.03 seconds (3.91 work units)
+Optimal objective  2.174035714e+02
+"""
+expected_summary_concurrent = {"BarIterCount": 7, "IterCount": 69986, "Runtime": 4.03}
+expected_progress_concurrent = [
+    {
+        "Iteration": 0,
+        "Indicator": " ",
+        "PObj": 45643508.5,
+        "DObj": 15306.1018,
+        "PRes": 169000.0,
+        "DRes": 8.58,
+        "Compl": 1590.0,
+        "Time": 2,
+    },
+]
+
 example_log_relaxation = """
 Root relaxation: objective 4.473603e+00, 25 iterations, 0.01 seconds
 """
@@ -144,18 +170,21 @@ class TestSimplexLog(TestCase):
             [
                 example_log_simplex,
                 example_log_barrier,
+                example_log_concurrent,
                 example_log_relaxation,
                 example_log_mip,
             ],
             [
                 expected_summary_simplex,
                 expected_summary_barrier,
+                expected_summary_concurrent,
                 expected_summary_relaxation,
                 expected_summary_mip,
             ],
             [
                 expected_progress_simplex,
                 expected_progress_barrier,
+                expected_progress_concurrent,
                 expected_progress_relaxation,
                 expected_progress_mip,
             ],

--- a/tests/parsers/test_continuous.py
+++ b/tests/parsers/test_continuous.py
@@ -143,7 +143,7 @@ expected_progress_mip = [
 ]
 
 
-class TestSimplexLog(TestCase):
+class TestContinuous(TestCase):
     def setUp(self):
         pass
 

--- a/tests/parsers/test_header.py
+++ b/tests/parsers/test_header.py
@@ -74,7 +74,7 @@ expected_parameters_2 = {
 }
 
 
-class TestHeaderLog(TestCase):
+class TestHeader(TestCase):
     def setUp(self):
         pass
 

--- a/tests/parsers/test_presolve.py
+++ b/tests/parsers/test_presolve.py
@@ -126,7 +126,7 @@ expected_summary_2 = {
 }
 
 
-class TestHeader(TestCase):
+class TestPresolve(TestCase):
     def setUp(self):
         pass
 

--- a/tests/parsers/test_presolve.py
+++ b/tests/parsers/test_presolve.py
@@ -126,7 +126,7 @@ expected_summary_2 = {
 }
 
 
-class TestHeaderLog(TestCase):
+class TestHeader(TestCase):
     def setUp(self):
         pass
 

--- a/tests/parsers/test_single_log.py
+++ b/tests/parsers/test_single_log.py
@@ -39,11 +39,11 @@ def test_mip_norel_log():
     assert summary["ObjVal"] == 1.2000126e09
     assert summary["Runtime"] == 93.70
 
-    norel_progress = parser.get_norel_progress()
+    norel_progress = parser.norel_parser.get_progress()
     assert len(norel_progress) == 15
-    rootlp_progress = parser.get_rootlp_progress()
+    rootlp_progress = parser.continuous_parser.get_progress()
     assert len(rootlp_progress) == 2
-    nodelog_progress = parser.get_nodelog_progress()
+    nodelog_progress = parser.nodelog_parser.get_progress()
     assert len(nodelog_progress) == 6
 
 
@@ -68,7 +68,7 @@ def test_lp_barrier():
     assert summary["Runtime"] == 4.83
     assert summary["Status"] == "OPTIMAL"
 
-    rootlp_progress = parser.get_rootlp_progress()
+    rootlp_progress = parser.continuous_parser.get_progress()
     assert len(rootlp_progress) == 18
 
 
@@ -90,5 +90,5 @@ def test_lp_simplex():
     assert summary["Runtime"] == 300.00
     assert summary["Status"] == "TIME_LIMIT"
 
-    rootlp_progress = parser.get_rootlp_progress()
+    rootlp_progress = parser.continuous_parser.get_progress()
     assert len(rootlp_progress) == 60

--- a/tests/parsers/test_single_log.py
+++ b/tests/parsers/test_single_log.py
@@ -50,15 +50,15 @@ def test_lp_barrier():
     assert parser.continuous_parser.get_summary()
     assert not parser.norel_parser.get_summary()
     assert not parser.nodelog_parser.get_summary()
-    assert parser.termination_parser.get_summary()  # fail
+    assert parser.termination_parser.get_summary()
     # Combined summary data.
     summary = parser.get_summary()
     assert summary["Version"] == "9.5.0"
     assert summary["Model"] == "savsched1"  # fail
-    assert summary["OrderingTime"] == 0.41  # fail
+    assert summary["OrderingTime"] == 0.41
     assert summary["BarIterCount"] == 17
     assert summary["Runtime"] == 4.83
-    assert summary["Status"] == "OPTIMAL"  # fail
+    assert summary["Status"] == "OPTIMAL"
 
 
 def test_lp_simplex():

--- a/tests/parsers/test_single_log.py
+++ b/tests/parsers/test_single_log.py
@@ -21,11 +21,12 @@ def test_mip_norel_log():
     assert parser.header_parser.get_summary()
     assert parser.presolve_parser.get_summary()
     assert parser.norel_parser.get_summary()
-    assert parser.norel_parser.timeline
+    assert parser.norel_parser.get_progress()
     assert parser.continuous_parser.get_summary()
     assert parser.continuous_parser.get_progress()
     assert parser.nodelog_parser.get_summary()
-    assert parser.nodelog_parser.timeline
+    assert parser.nodelog_parser.get_progress()
+    assert parser.termination_parser.get_summary()
     # Combined summary data.
     summary = parser.get_summary()
     assert summary["Version"] == "9.1.2"
@@ -37,6 +38,13 @@ def test_mip_norel_log():
     assert summary["Status"] == "OPTIMAL"
     assert summary["ObjVal"] == 1.2000126e09
     assert summary["Runtime"] == 93.70
+
+    norel_progress = parser.get_norel_progress()
+    assert len(norel_progress) == 15
+    rootlp_progress = parser.get_rootlp_progress()
+    assert len(rootlp_progress) == 2
+    nodelog_progress = parser.get_nodelog_progress()
+    assert len(nodelog_progress) == 6
 
 
 @pytest.mark.xfail
@@ -60,6 +68,9 @@ def test_lp_barrier():
     assert summary["Runtime"] == 4.83
     assert summary["Status"] == "OPTIMAL"
 
+    rootlp_progress = parser.get_rootlp_progress()
+    assert len(rootlp_progress) == 18
+
 
 def test_lp_simplex():
     parser = SingleLogParser()
@@ -78,3 +89,6 @@ def test_lp_simplex():
     assert summary["IterCount"] == 75321
     assert summary["Runtime"] == 300.00
     assert summary["Status"] == "TIME_LIMIT"
+
+    rootlp_progress = parser.get_rootlp_progress()
+    assert len(rootlp_progress) == 60

--- a/tests/parsers/test_termination.py
+++ b/tests/parsers/test_termination.py
@@ -46,6 +46,8 @@ expected_summary_2 = {
     "SolCount": 10,
     "ObjBound": 1200006450.0,
     "MIPGap": 5e-06,
+    "Threads": 8,
+    "Cores": 8,
 }
 
 

--- a/tests/parsers/test_termination.py
+++ b/tests/parsers/test_termination.py
@@ -1,49 +1,70 @@
+from unittest import TestCase, main
+
 from grblogtools.parsers.termination import TerminationParser
-from grblogtools.parsers.util import parse_block
 
-# TODO add tests for other status parsers
+example_log_0 = """
+Barrier performed 302 iterations in 500.18 seconds
+Sub-optimal termination - objective 5.14914644e+03
+"""
+expected_summary_0 = {
+    "Status": "SUBOPTIMAL",
+    "ObjVal": 5149.14644,
+}
 
-test_lines_1 = """
+example_log_1 = """
+Barrier performed 7 iterations in 4.02 seconds (4.19 work units)
+Barrier solve interrupted - model solved by another algorithm
+
+
+Solved with dual simplex
+Solved in 69986 iterations and 4.03 seconds (3.91 work units)
+Optimal objective  2.174035714e+02
+"""
+expected_summary_1 = {
+    "Status": "OPTIMAL",
+    "ObjVal": 217.4035714,
+}
+
+example_log_2 = """
+Barrier solved model in 17 iterations and 4.83 seconds (6.45 work units)
+Optimal objective 8.000024e+08
+
+Root relaxation: objective 8.000024e+08, 72 iterations, 30.00 seconds
+
+Explored 5135 nodes (36786 simplex iterations) in 93.70 seconds
 Thread count was 8 (of 8 available processors)
-Solution count 10: 1.20001e+09 1.26668e+09 1.40001e+09 ... 1.50001e+09
+
+Solution count 10: 1.20001e+09 1.40001e+09 1.45001e+09 ... 1.60001e+09
+
 Optimal solution found (tolerance 1.00e-04)
-Best objective 1.200012600000e+09, best bound 1.200012600000e+09, gap 0.0000%
+Best objective 1.200012600000e+09, best bound 1.200006450000e+09, gap 0.0005%
 """
 
-
-test_lines_2 = """
-Thread count was 8 (of 8 available processors)
-
-Solution count 10: 1.50001e+09 1.50001e+09 1.50001e+09 ... 1.60001e+09
-
-Time limit reached
-Best objective 1.500006024411e+09, best bound 9.000096250000e+08, gap 39.9996%
-"""
+expected_summary_2 = {
+    "Status": "OPTIMAL",
+    "ObjVal": 1200012600.0,
+    "SolCount": 10,
+    "ObjBound": 1200006450.0,
+    "MIPGap": 5e-06,
+}
 
 
-def test_termination_parser_1():
-    parser = TerminationParser()
-    parse_block(parser, test_lines_1)
-    assert parser.get_summary() == {
-        "Threads": 8,  # clashes with the HeaderParser result (should always match)
-        "Cores": 8,  # should always match logical cores?
-        "SolCount": 10,
-        "ObjVal": 1.2000126e09,
-        "ObjBound": 1.2000126e09,
-        "MIPGap": 0.0,
-        "Status": "OPTIMAL",
-    }
+class TestTermination(TestCase):
+    def setUp(self):
+        pass
+
+    def test_get_summary(self):
+        for example_log, expected_summary in zip(
+            [example_log_0, example_log_1, example_log_2],
+            [expected_summary_0, expected_summary_1, expected_summary_2],
+        ):
+            with self.subTest(example_log=example_log):
+                parser = TerminationParser()
+                lines = iter(example_log.strip().split("\n"))
+                for line in lines:
+                    parser.parse(line)
+                self.assertEqual(parser.get_summary(), expected_summary)
 
 
-def test_termination_parser_2():
-    parser = TerminationParser()
-    parse_block(parser, test_lines_2)
-    assert parser.get_summary() == {
-        "Threads": 8,
-        "Cores": 8,
-        "SolCount": 10,
-        "ObjVal": 1.500006024411e09,
-        "ObjBound": 9.000096250000e08,
-        "MIPGap": 0.399996,
-        "Status": "TIME_LIMIT",
-    }
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,8 +16,19 @@ def glass4_summary():
 
 
 @pytest.fixture(scope="module")
+def glass4_progress():
+    """Progress data from API call."""
+    return glt.parse("data/*.log").progress()
+
+
+@pytest.fixture(scope="module")
 def testlog_summary():
     return glt.parse("tests/assets/*.log").summary()
+
+
+@pytest.fixture(scope="module")
+def testlog_progress():
+    return glt.parse("tests/assets/*.log").progress()
 
 
 @pytest.fixture(scope="module")
@@ -50,10 +61,36 @@ def test_summary(testlog_summary):
     )
 
 
+def test_progress(testlog_progress):
+    assert len(testlog_progress) == 3
+    assert len(testlog_progress["norel"]) == 15
+    assert set(testlog_progress["norel"].columns).issuperset(
+        {"Time", "BestBd", "Incumbent"}
+    )
+    assert len(testlog_progress["rootlp"]) == 88
+    assert set(testlog_progress["rootlp"].columns).issuperset(
+        {"Iteration", "PInf", "DInf", "PObj", "DObj"}
+    )
+    assert len(testlog_progress["nodelog"]) == 6
+    assert set(testlog_progress["nodelog"].columns).issuperset(
+        {"Depth", "IntInf", "Incumbent", "BestBd", "ItPerNode"}
+    )
+
+
 def test_summary_glass4(glass4_summary):
     assert len(glass4_summary) == 63
     assert set(glass4_summary.columns).issuperset(
         {"Status", "ObjVal", "ReadTime", "RelaxObj", "Seed"}
+    )
+
+
+def test_progress_glass4(glass4_progress):
+    assert len(glass4_progress) == 3
+    assert len(glass4_progress["norel"]) == 0
+    assert len(glass4_progress["rootlp"]) == 0
+
+    assert set(glass4_progress["nodelog"].columns).issuperset(
+        {"Depth", "IntInf", "Incumbent", "BestBd", "ItPerNode"}
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,11 @@ def glass4_summary():
 @pytest.fixture(scope="module")
 def glass4_progress():
     """Progress data from API call."""
-    return glt.parse("data/*.log").progress()
+    return {
+        "norel": glt.parse("data/*.log").progress("norel"),
+        "rootlp": glt.parse("data/*.log").progress("rootlp"),
+        "nodelog": glt.parse("data/*.log").progress("nodelog"),
+    }
 
 
 @pytest.fixture(scope="module")
@@ -28,7 +32,11 @@ def testlog_summary():
 
 @pytest.fixture(scope="module")
 def testlog_progress():
-    return glt.parse("tests/assets/*.log").progress()
+    return {
+        "norel": glt.parse("tests/assets/*.log").progress("norel"),
+        "rootlp": glt.parse("tests/assets/*.log").progress("rootlp"),
+        "nodelog": glt.parse("tests/assets/*.log").progress("nodelog"),
+    }
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Closes #23 
Closes #25 

This PR:
- Reworks the termination parser. All the regex expressions related to termination messages and statuses are included in the termination parser. No expression is duplicated in any other parser. Likely there are other ideas to achieve the same thing, but the current approach was chosen because it includes all the regexs in one parser.
- The method `get_progress()` is added to the `norel` and `nodelog` parsers and the methods `get_nodelog_progress()`, `get_norel_progress()`, and `get_rootlp_progress()` are added to the `single_parser`. These methods are necessary to add the method `progress()` to the `ParseResult`. The choice of `progress` over `timelines` is just a personal preference and we can definitely choose a different name or stick to `timelines`. There is also the question of whether we need the `get_progress()` method for sub parsers or we can use the `timeline` (or `progress`) attribute. This is also a personal preference. We can definitely discuss these in our meeting to finalize all API changes to address them all in #27.
- The `timelines` flag is added to the legacy method `get_dataframe()`. 
- The `single_parser` is slightly modified given the changes in the `termination_parser`.
- Tests are included for the `termination_parser`, the `single_parser`, and the `api`. The tests for the `single_parser` and the `api` are added to the tests previously written. The tests can be extended as we add more example log files.
- The `barrier` and the `continuous` parsers are slightly modified to include the case of concurrent optimization where barrier is interrupted and another algorithm takes over.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201705063151541