### PR TITLE
pre-commit checks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,10 @@ envlist = py37,py38,py39,py310,pre-commit
 
 [gh-actions]
 python =
-    3.7: py37,pre-commit
-    3.8: py38,pre-commit
+    3.7: py37
+    3.8: py38
     3.9: py39,pre-commit
-    3.10: py310,pre-commit
+    3.10: py310
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
Removes pre-commit checks from all Python env except 3.9